### PR TITLE
add v3 fee check, fix v2 fee filename

### DIFF
--- a/.github/workflows/get_mimic_report.yaml
+++ b/.github/workflows/get_mimic_report.yaml
@@ -42,6 +42,7 @@ jobs:
             Checks before merging:
             - [ ] assert total wei of the json == [wei onchain](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48?a=0x7c68c42de679ffb0f16216154c996c354cf1161b)
             - [ ] all active chains present
+            - [ ] v3 fees are uploaded (v3_fees_{start_date}_{end_date}.json)
           branch: gha-mimic-fees
           branch-suffix: timestamp
           delete-branch: true

--- a/fee_allocator/fees_collected/get_report.py
+++ b/fee_allocator/fees_collected/get_report.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
         report = get_report(yesterday.strftime("%Y-%m-%d"), today.strftime("%Y-%m-%d"))
         with open(
-            f"fee_allocator/fees_collected/fees_{epoch_start.strftime('%Y-%m-%d')}_{today.strftime('%Y-%m-%d')}.json",
+            f"fee_allocator/fees_collected/v2_fees_{epoch_start.strftime('%Y-%m-%d')}_{today.strftime('%Y-%m-%d')}.json",
             "w",
         ) as f:
             json.dump(report, f, indent=2)


### PR DESCRIPTION
#86, also now prefix mimic generated fees file name with "v2" automatically. 

mimic action currently targets `test-workflow` branch (https://github.com/BalancerMaxis/protocol_fee_allocator_v2/pull/39), so the paladin check as well as others had to be added there: [378de9c](https://github.com/BalancerMaxis/protocol_fee_allocator_v2/pull/39/commits/378de9c9806eb1f3b65b321f9401553c3210e142)