### PR TITLE
add explorer env vars to actions

### DIFF
--- a/.github/workflows/collect_fees.yaml
+++ b/.github/workflows/collect_fees.yaml
@@ -32,6 +32,11 @@ jobs:
         env:
           DRPC_KEY: ${{ secrets.DRPC_KEY }}
           GRAPH_API_KEY: ${{ secrets.GRAPH_API_KEY }}
+          EXPLORER_API_KEY_MAINNET: ${{ secrets.EXPLORER_API_KEY_MAINNET }}
+          EXPLORER_API_KEY_ARBITRUM: ${{ secrets.EXPLORER_API_KEY_ARBITRUM }}
+          EXPLORER_API_KEY_POLYGON: ${{ secrets.EXPLORER_API_KEY_POLYGON }}
+          EXPLORER_API_KEY_BASE: ${{ secrets.EXPLORER_API_KEY_BASE }}
+          EXPLORER_API_KEY_GNOSIS: ${{ secrets.EXPLORER_API_KEY_GNOSIS }}
         run: |
           end_day=${{ inputs.end_day }}
           start_day=$(date -d "$end_day -14 days" +%Y-%m-%d)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,5 +28,10 @@ jobs:
         env:
           DRPC_KEY: ${{ secrets.DRPC_KEY }}
           GRAPH_API_KEY: ${{ secrets.GRAPH_API_KEY }}
+          EXPLORER_API_KEY_MAINNET: ${{ secrets.EXPLORER_API_KEY_MAINNET }}
+          EXPLORER_API_KEY_ARBITRUM: ${{ secrets.EXPLORER_API_KEY_ARBITRUM }}
+          EXPLORER_API_KEY_POLYGON: ${{ secrets.EXPLORER_API_KEY_POLYGON }}
+          EXPLORER_API_KEY_BASE: ${{ secrets.EXPLORER_API_KEY_BASE }}
+          EXPLORER_API_KEY_GNOSIS: ${{ secrets.EXPLORER_API_KEY_GNOSIS }}
         run: |
           python -m pytest -v -s --timeout=300

--- a/.github/workflows/trigger_fee_collection.yaml
+++ b/.github/workflows/trigger_fee_collection.yaml
@@ -55,6 +55,11 @@ jobs:
         env:
           DRPC_KEY: ${{ secrets.DRPC_KEY }}
           GRAPH_API_KEY: ${{ secrets.GRAPH_API_KEY }}
+          EXPLORER_API_KEY_MAINNET: ${{ secrets.EXPLORER_API_KEY_MAINNET }}
+          EXPLORER_API_KEY_ARBITRUM: ${{ secrets.EXPLORER_API_KEY_ARBITRUM }}
+          EXPLORER_API_KEY_POLYGON: ${{ secrets.EXPLORER_API_KEY_POLYGON }}
+          EXPLORER_API_KEY_BASE: ${{ secrets.EXPLORER_API_KEY_BASE }}
+          EXPLORER_API_KEY_GNOSIS: ${{ secrets.EXPLORER_API_KEY_GNOSIS }}
         run: |
           pwd
           end_day=${{ steps.get-date.outputs.end-date }}

--- a/.github/workflows/update_earned_fees.yaml
+++ b/.github/workflows/update_earned_fees.yaml
@@ -30,6 +30,11 @@ jobs:
         env:
           DRPC_KEY: ${{ secrets.DRPC_KEY }}
           GRAPH_API_KEY: ${{ secrets.GRAPH_API_KEY }}
+          EXPLORER_API_KEY_MAINNET: ${{ secrets.EXPLORER_API_KEY_MAINNET }}
+          EXPLORER_API_KEY_ARBITRUM: ${{ secrets.EXPLORER_API_KEY_ARBITRUM }}
+          EXPLORER_API_KEY_POLYGON: ${{ secrets.EXPLORER_API_KEY_POLYGON }}
+          EXPLORER_API_KEY_BASE: ${{ secrets.EXPLORER_API_KEY_BASE }}
+          EXPLORER_API_KEY_GNOSIS: ${{ secrets.EXPLORER_API_KEY_GNOSIS }}
         run: |
           pwd
           python generate_earned_fees.py

--- a/.github/workflows/update_earned_fees.yaml
+++ b/.github/workflows/update_earned_fees.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "biweekly-runs"
+          ref: "collect-fees-cron"
 
       - name: Setup Python 3.10
         uses: actions/setup-python@v5
@@ -42,6 +42,6 @@ jobs:
       - name: Commit CSV files
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          branch: "biweekly-runs"
+          branch: "collect-fees-cron"
           file_pattern: "fee_allocator/allocations/incentives/current_fees/*_earned_fees_*.csv"
           commit_message: "ci: update core pool earned fees CSVs"


### PR DESCRIPTION
adds explorer api keys for all actions that run the allocator. these keys are used for block fetching from timestamp. using the subgraph to do this doesnt seem be working atm as it fails to fetch arbitrum block number from two weeks ago: https://github.com/BalancerMaxis/protocol_fee_allocator_v2/actions/runs/15663177703/job/44123853430z

all env vars are already added as repo secrets
