### PR TITLE
change allocation behavior for chains with no core pools 

### DIFF
--- a/fee_allocator/accounting/chains.py
+++ b/fee_allocator/accounting/chains.py
@@ -83,10 +83,9 @@ class CorePoolRunConfig:
     def set_core_pool_chains_data(self):
         """
         iterate over each chain in `input_fees` and fetch that chain's core pool data
-        only chains that have core pools and non-zero fees are initialized, else the fees are redistributed to other chains
+        chains with no core pools will have their fees allocated to dao/vebal only
         """
         _chains: dict[str, CorePoolChain] = {}
-        unallocated_fees: dict[str, Decimal] = {}
 
         for chain_name, fees in self.input_fees.items():
             if fees == 0:
@@ -99,19 +98,9 @@ class CorePoolRunConfig:
             if chain.pool_fee_data:
                 _chains[chain_name] = chain
             else:
-                print(f"no core pools for {chain_name}. allocating fees to other chains...")
-                unallocated_fees[chain_name] = Decimal(fees)
-
-        # second pass; redistibute unallocated fees pro rata
-        if unallocated_fees and _chains:
-            total_earned_fees = sum(chain.total_earned_fees_usd_twap for chain in _chains.values())
-            total_unallocated = sum(unallocated_fees.values())
-
-            for chain in _chains.values():
-                if total_earned_fees > 0:
-                    chain_share = chain.total_earned_fees_usd_twap / total_earned_fees
-                    chain.fees_collected += total_unallocated * chain_share
-                    print(f"adding {total_unallocated * chain_share} fees to {chain.name} ({chain_share:.2%} of unallocated fees)")
+                print(f"no core pools for {chain_name}")
+                chain.pool_fee_data = []
+                _chains[chain_name] = chain
 
         self._chains = _chains
 
@@ -292,7 +281,9 @@ class CorePoolChain(AbstractCorePoolChain):
         """
         fetches various chain data from subgraph and returns a list of `PoolFeeData` based on the core pool list
         """
-        if not self.bal_pools_gauges.core_pools:
+        self._init_alliance_pools()
+
+        if not self.bal_pools_gauges.core_pools and not self.alliance_pools:
             return []
 
         logger.info(f"getting snapshots for {self.name}")
@@ -314,8 +305,6 @@ class CorePoolChain(AbstractCorePoolChain):
             if self.core_pools_list is not None
             else self.bal_pools_gauges.core_pools
         )
-
-        self._init_alliance_pools()
 
         alliance_pool_tuples = [(pool.pool_id, pool.partner) for pool in self.alliance_pools]
 
@@ -471,7 +460,7 @@ class CorePoolChain(AbstractCorePoolChain):
     @property
     @require_pool_fee_data
     def noncore_fees_collected(self) -> Decimal:
-        return max(self.fees_collected - self.total_earned_fees_usd_twap, Decimal(0))
+        return max(self.fees_collected - self.total_earned_fees_usd_twap - self.alliance_noncore_fees_collected, Decimal(0))
 
     @property
     @require_pool_fee_data
@@ -486,7 +475,7 @@ class CorePoolChain(AbstractCorePoolChain):
     @property
     @require_pool_fee_data
     def total_fees_earned(self) -> Decimal:
-        return self.total_earned_fees_usd_twap + self.noncore_fees_collected
+        return self.total_earned_fees_usd_twap + self.noncore_fees_collected + self.alliance_noncore_fees_collected
     
     @property
     def alliance_noncore_fees_collected(self) -> Decimal:

--- a/fee_allocator/fee_allocator.py
+++ b/fee_allocator/fee_allocator.py
@@ -430,7 +430,7 @@ class FeeAllocator:
         payment_df = df[df["platform"] == "payment"].iloc[0]
 
         total_bribe_usdc = sum(round(row["amount"] * 1e6) for _, row in bribe_df.iterrows())
-        dao_fee_usdc = round(payment_df["amount"] * 1e6)
+        dao_fee_usdc = round(payment_df["amount"] * 1e6) - 1000  # round down 0.1 cent
 
         """bribe txs"""
         usdc.approve(self.book["hidden_hand2/bribe_vault"], total_bribe_usdc + 1) # 1 wei buffer

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -102,18 +102,19 @@ def test_core_pool_allocation(allocated_allocator: FeeAllocator):
     
     for chain in allocated_allocator.run_config.all_chains:
         for pool in chain.core_pools:
-            # Only include standard core pools (exclude alliance pools with partners)
-            if not (hasattr(pool, 'to_partner_usd') and pool.to_partner_usd > 0):
-                total_core_fees += pool.total_earned_fees_usd_twap
+            # Only include standard core pools
+            if not pool.is_alliance_pool:
                 total_core_dao += pool.to_dao_usd
                 total_core_vebal += pool.to_vebal_usd
                 total_core_incentives += pool.total_to_incentives_usd
-    
-    if total_core_fees > 0:
-        core_dao_pct = total_core_dao / total_core_fees
-        core_vebal_pct = total_core_vebal / total_core_fees
-        core_incentives_pct = total_core_incentives / total_core_fees
-        
+
+    total_core_allocations = total_core_dao + total_core_vebal + total_core_incentives
+
+    if total_core_allocations > 0:
+        core_dao_pct = total_core_dao / total_core_allocations
+        core_vebal_pct = total_core_vebal / total_core_allocations
+        core_incentives_pct = total_core_incentives / total_core_allocations
+
         assert abs(core_dao_pct - fee_config.dao_share_pct) <= Decimal('0.02'), \
             f"Core pool DAO {core_dao_pct:.4f} not within 2% of target {fee_config.dao_share_pct}"
         assert abs(core_vebal_pct - fee_config.vebal_share_pct) <= Decimal('0.02'), \


### PR DESCRIPTION
#151 - chain with no core pools in fees collected json will now allocate to dao/vebal instead of distributing its fees to other chains. also handles an additonal edge case where a chain has fees collected, no core pools but *does* have an alliance non-core pool