### PR TITLE
Partner-fee-split-minors

### DIFF
--- a/fee_allocator/accounting/chains.py
+++ b/fee_allocator/accounting/chains.py
@@ -509,6 +509,10 @@ class CorePoolChain(AbstractCorePoolChain):
         except NoPricesFoundError:
             return None
         
+    def get_beets_factor(self) -> Decimal:
+        """Returns the Beets share factor for this chain (0.5 for Optimism, 0 for others)"""
+        return Decimal(self.chains.fee_config.beets_share_pct) if self.name == "optimism" else Decimal(0)
+    
     def get_alliance_noncore_partner_fee(self, pool_id: str) -> Decimal:
         noncore_pool = next((p for p in self.alliance_noncore_fee_data if p.pool_id == pool_id), None)
         if not noncore_pool or self.alliance_noncore_fees_collected == 0:
@@ -551,22 +555,22 @@ class CorePoolChain(AbstractCorePoolChain):
     @property
     @require_pool_fee_data
     def noncore_to_dao_usd(self) -> Decimal:
-        beets_share_pct = self.chains.fee_config.beets_share_pct if self.name == "optimism" else 0
-        return self.noncore_fees_collected * (1 - beets_share_pct) * self.chains.fee_config.noncore_dao_share_pct
+        beets_factor = self.get_beets_factor()
+        return self.noncore_fees_collected * (1 - beets_factor) * self.chains.fee_config.noncore_dao_share_pct
 
     @property
     @require_pool_fee_data
     def noncore_to_vebal_usd(self) -> Decimal:
-        beets_share_pct = self.chains.fee_config.beets_share_pct if self.name == "optimism" else 0
-        return self.noncore_fees_collected * (1 - beets_share_pct) * self.chains.fee_config.noncore_vebal_share_pct
+        beets_factor = self.get_beets_factor()
+        return self.noncore_fees_collected * (1 - beets_factor) * self.chains.fee_config.noncore_vebal_share_pct
     
     @property
     @require_pool_fee_data
     def noncore_to_beets_usd(self) -> Decimal:
-        beets_share_pct = self.chains.fee_config.beets_share_pct if self.name == "optimism" else 0
-        if beets_share_pct == 0:
+        beets_factor = self.get_beets_factor()
+        if beets_factor == 0:
             return Decimal(0)
-        return self.noncore_fees_collected * beets_share_pct
+        return self.noncore_fees_collected * beets_factor
 
     @property
     @require_pool_fee_data
@@ -579,20 +583,20 @@ class CorePoolChain(AbstractCorePoolChain):
 
     @property
     def alliance_noncore_to_dao_usd(self) -> Decimal:
-        beets_share_pct = self.chains.fee_config.beets_share_pct if self.name == "optimism" else 0
-        return self.alliance_noncore_fees_collected * self.chains.alliance_config.alliance_fee_allocations["non_core"].dao_share_pct * (1 - beets_share_pct)
+        beets_factor = self.get_beets_factor()
+        return self.alliance_noncore_fees_collected * self.chains.alliance_config.alliance_fee_allocations["non_core"].dao_share_pct * (1 - beets_factor)
 
     @property
     def alliance_noncore_to_vebal_usd(self) -> Decimal:
-        beets_share_pct = self.chains.fee_config.beets_share_pct if self.name == "optimism" else 0
-        return self.alliance_noncore_fees_collected * self.chains.alliance_config.alliance_fee_allocations["non_core"].vebal_share_pct  * (1 - beets_share_pct)
+        beets_factor = self.get_beets_factor()
+        return self.alliance_noncore_fees_collected * self.chains.alliance_config.alliance_fee_allocations["non_core"].vebal_share_pct  * (1 - beets_factor)
 
     @property
     def alliance_noncore_to_beets_usd(self) -> Decimal:
-        beets_share_pct = self.chains.fee_config.beets_share_pct if self.name == "optimism" else 0
-        if beets_share_pct == 0:
+        beets_factor = self.get_beets_factor()
+        if beets_factor == 0:
             return Decimal(0)
-        return self.alliance_noncore_fees_collected * (1 - self.chains.alliance_config.alliance_fee_allocations["non_core"].partner_share_pct) * beets_share_pct
+        return self.alliance_noncore_fees_collected * (1 - self.chains.alliance_config.alliance_fee_allocations["non_core"].partner_share_pct) * beets_factor
     
     @property
     def partner_noncore_fees_collected(self) -> Decimal:
@@ -625,8 +629,8 @@ class CorePoolChain(AbstractCorePoolChain):
             if partner_info:
                 _, fee_config = partner_info
                 pool_share = pool.total_earned_fees_usd_twap / self.partner_noncore_fees_collected if self.partner_noncore_fees_collected > 0 else Decimal(0)
-                beets_share_pct = self.chains.fee_config.beets_share_pct if self.name == "optimism" else 0
-                total += self.partner_noncore_fees_collected * pool_share * fee_config.dao_share_pct * (1 - beets_share_pct)
+                beets_factor = self.get_beets_factor()
+                total += self.partner_noncore_fees_collected * pool_share * fee_config.dao_share_pct * (1 - beets_factor)
         return total
     
     @property
@@ -638,15 +642,15 @@ class CorePoolChain(AbstractCorePoolChain):
             if partner_info:
                 _, fee_config = partner_info
                 pool_share = pool.total_earned_fees_usd_twap / self.partner_noncore_fees_collected if self.partner_noncore_fees_collected > 0 else Decimal(0)
-                beets_share_pct = self.chains.fee_config.beets_share_pct if self.name == "optimism" else 0
-                total += self.partner_noncore_fees_collected * pool_share * fee_config.vebal_share_pct * (1 - beets_share_pct)
+                beets_factor = self.get_beets_factor()
+                total += self.partner_noncore_fees_collected * pool_share * fee_config.vebal_share_pct * (1 - beets_factor)
         return total
     
     @property
     def partner_noncore_to_beets_usd(self) -> Decimal:
         """Beets fees from partner non-core pools (Optimism only)"""
-        beets_share_pct = self.chains.fee_config.beets_share_pct if self.name == "optimism" else 0
-        if beets_share_pct == 0:
+        beets_factor = self.get_beets_factor()
+        if beets_factor == 0:
             return Decimal(0)
         
         total = Decimal(0)
@@ -656,7 +660,7 @@ class CorePoolChain(AbstractCorePoolChain):
                 _, fee_config = partner_info
                 pool_share = pool.total_earned_fees_usd_twap / self.partner_noncore_fees_collected if self.partner_noncore_fees_collected > 0 else Decimal(0)
                 # Beets gets a share of the non-partner portion
-                total += self.partner_noncore_fees_collected * pool_share * (1 - fee_config.partner_share_pct) * beets_share_pct
+                total += self.partner_noncore_fees_collected * pool_share * (1 - fee_config.partner_share_pct) * beets_factor
         return total
 
     @property

--- a/fee_allocator/accounting/core_pools.py
+++ b/fee_allocator/accounting/core_pools.py
@@ -129,6 +129,11 @@ class PoolFee(AbstractPoolFee, PoolFeeData):
     def _check_if_partner_pool(self) -> bool:
         return self.chain.chains.alliance_config.get_partner_pool_config(self.pool_id, self.chain.name) is not None
     
+    @property
+    def is_alliance_core_pool(self) -> bool:
+        """Returns True if this is an Alliance pool with core type (not non-core)"""
+        return self.is_alliance_pool and not self.is_alliance_non_core_pool
+    
     def _get_partner_info(self):
         return self.chain.chains.alliance_config.get_partner_pool_config(self.pool_id, self.chain.name)
     
@@ -159,7 +164,7 @@ class PoolFee(AbstractPoolFee, PoolFeeData):
 
         if self.is_alliance_pool:
             vote_incentive_pct = self.chain.chains.alliance_config.alliance_fee_allocations["core"].vote_incentive_pct
-        elif self.is_partner_pool:
+        elif self.is_partner_pool and self.partner_info:
             _, fee_config = self.partner_info
             vote_incentive_pct = fee_config.vote_incentive_pct
         else:
@@ -170,7 +175,7 @@ class PoolFee(AbstractPoolFee, PoolFeeData):
 
     def _calculate_incentive_split(self, platform: str) -> Decimal:
         # Alliance core pools get 100% to AURA
-        if self.is_alliance_pool and not self.is_alliance_non_core_pool:
+        if self.is_alliance_core_pool:
             return self.total_to_incentives_usd if platform == "aura" else Decimal(0)
         
         if self.voting_pool_override == platform:
@@ -190,31 +195,31 @@ class PoolFee(AbstractPoolFee, PoolFeeData):
 
     def _to_dao_usd(self) -> Decimal:
         core_fees = self._core_pool_allocation()
-        beets_share_pct = self.chain.chains.fee_config.beets_share_pct if self.chain.name == "optimism" else 0
+        beets_factor = self.chain.get_beets_factor()
         
         if self.is_alliance_non_core_pool or self.is_alliance_pool:
             dao_share_pct = self.alliance_fee_config.dao_share_pct
-        elif self.is_partner_pool:
+        elif self.is_partner_pool and self.partner_info:
             _, fee_config = self.partner_info
             dao_share_pct = fee_config.dao_share_pct
         else:
             dao_share_pct = self.chain.chains.fee_config.dao_share_pct
             
-        return self.earned_fee_share_of_chain_usd * core_fees * dao_share_pct * (1 - beets_share_pct)
+        return self.earned_fee_share_of_chain_usd * core_fees * dao_share_pct * (1 - beets_factor)
 
     def _to_vebal_usd(self) -> Decimal:
         core_fees = self._core_pool_allocation()
-        beets_share_pct = self.chain.chains.fee_config.beets_share_pct if self.chain.name == "optimism" else 0
+        beets_factor = self.chain.get_beets_factor()
         
         if self.is_alliance_non_core_pool or self.is_alliance_pool:
             vebal_share_pct = self.alliance_fee_config.vebal_share_pct
-        elif self.is_partner_pool:
+        elif self.is_partner_pool and self.partner_info:
             _, fee_config = self.partner_info
             vebal_share_pct = fee_config.vebal_share_pct
         else:
             vebal_share_pct = self.chain.chains.fee_config.vebal_share_pct
             
-        return self.earned_fee_share_of_chain_usd * core_fees * vebal_share_pct * (1 - beets_share_pct)
+        return self.earned_fee_share_of_chain_usd * core_fees * vebal_share_pct * (1 - beets_factor)
 
     def _to_partner_usd(self) -> Decimal:
         core_fees = self._core_pool_allocation()
@@ -235,7 +240,21 @@ class PoolFee(AbstractPoolFee, PoolFeeData):
         return Decimal(0)
         
     def _to_beets_usd(self) -> Decimal:
-        beets_share_pct = self.chain.chains.fee_config.beets_share_pct if self.chain.name == "optimism" else 0
-        if beets_share_pct == 0:
+        beets_factor = self.chain.get_beets_factor()
+        if beets_factor == 0:
             return Decimal(0)
-        return (self.to_dao_usd + self.to_vebal_usd)
+        # Beets receives the portion that was deducted from DAO and veBAL
+        core_fees = self._core_pool_allocation()
+        
+        if self.is_alliance_non_core_pool or self.is_alliance_pool:
+            dao_share_pct = self.alliance_fee_config.dao_share_pct
+            vebal_share_pct = self.alliance_fee_config.vebal_share_pct
+        elif self.is_partner_pool and self.partner_info:
+            _, fee_config = self.partner_info
+            dao_share_pct = fee_config.dao_share_pct
+            vebal_share_pct = fee_config.vebal_share_pct
+        else:
+            dao_share_pct = self.chain.chains.fee_config.dao_share_pct
+            vebal_share_pct = self.chain.chains.fee_config.vebal_share_pct
+            
+        return self.earned_fee_share_of_chain_usd * core_fees * (dao_share_pct + vebal_share_pct) * beets_factor

--- a/fee_allocator/accounting/models.py
+++ b/fee_allocator/accounting/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from decimal import Decimal
 from typing import Dict, NewType, Optional
 
@@ -70,6 +70,20 @@ class AllianceFeeAllocation(BaseModel):
     vote_incentive_pct: Decimal | None = None  # None for non-core pools
     partner_share_pct: Decimal
     dao_share_pct: Decimal
+    
+    @validator('dao_share_pct')
+    def validate_percentages(cls, v, values):
+        # For core pools (vote_incentive_pct is not None), all percentages must sum to 1
+        if 'vote_incentive_pct' in values and values['vote_incentive_pct'] is not None:
+            total = values['vote_incentive_pct'] + values.get('vebal_share_pct', 0) + values.get('partner_share_pct', 0) + v
+            if abs(total - Decimal('1')) > Decimal('0.0001'):
+                raise ValueError(f'Fee percentages must sum to 100%, got {total * 100}%')
+        # For non-core pools, vebal + partner + dao must sum to 1
+        elif 'vebal_share_pct' in values and 'partner_share_pct' in values:
+            total = values['vebal_share_pct'] + values['partner_share_pct'] + v
+            if abs(total - Decimal('1')) > Decimal('0.0001'):
+                raise ValueError(f'Fee percentages must sum to 100%, got {total * 100}%')
+        return v
 
 
 class AllianceThresholds(BaseModel):
@@ -98,6 +112,20 @@ class PartnerFeeAllocation(BaseModel):
     vote_incentive_pct: Decimal | None = None  # Only for core pools
     partner_share_pct: Decimal
     dao_share_pct: Decimal
+    
+    @validator('dao_share_pct')
+    def validate_percentages(cls, v, values):
+        # For core pools (vote_incentive_pct is not None), all percentages must sum to 1
+        if 'vote_incentive_pct' in values and values['vote_incentive_pct'] is not None:
+            total = values['vote_incentive_pct'] + values.get('vebal_share_pct', 0) + values.get('partner_share_pct', 0) + v
+            if abs(total - Decimal('1')) > Decimal('0.0001'):
+                raise ValueError(f'Fee percentages must sum to 100%, got {total * 100}%')
+        # For non-core pools, vebal + partner + dao must sum to 1
+        elif 'vebal_share_pct' in values and 'partner_share_pct' in values:
+            total = values['vebal_share_pct'] + values['partner_share_pct'] + v
+            if abs(total - Decimal('1')) > Decimal('0.0001'):
+                raise ValueError(f'Fee percentages must sum to 100%, got {total * 100}%')
+        return v
 
 
 class Partner(BaseModel):

--- a/fee_allocator/fee_allocator.py
+++ b/fee_allocator/fee_allocator.py
@@ -109,9 +109,8 @@ class FeeAllocator:
                 pool.total_to_incentives_usd += total
                 pool.redirected_incentives_usd += total
 
-                is_alliance_core = pool.is_alliance_pool and not pool.is_alliance_non_core_pool
-                pool.to_aura_incentives_usd += total if is_alliance_core else total * self.run_config.aura_vebal_share
-                pool.to_bal_incentives_usd += Decimal(0) if is_alliance_core else total * (1 - self.run_config.aura_vebal_share)
+                pool.to_aura_incentives_usd += total if pool.is_alliance_core_pool else total * self.run_config.aura_vebal_share
+                pool.to_bal_incentives_usd += Decimal(0) if pool.is_alliance_core_pool else total * (1 - self.run_config.aura_vebal_share)
 
         self._handle_aura_min(buffer=0.25)
         self._handle_aura_min()


### PR DESCRIPTION
Fixed None dereference: Added checks for `self.partner_info` before accessing it
Added fee percentage validation: Pydantic validators ensure all fee allocations sum to exactly 100%
Fixed Alliance logic: Created `is_alliance_core_pool` property for clearer code
Standardized Beets factor:
- Created `get_beets_factor()` helper method
- Fixed the double-application bug in `_to_beets_usd()`
- Standardized all Beets calculations to use the helper method