### PR TITLE
 dispatch to multisig-ops on fee report merge

### DIFF
--- a/.github/workflows/trigger_multisig_ops_sync.yaml
+++ b/.github/workflows/trigger_multisig_ops_sync.yaml
@@ -1,3 +1,7 @@
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
 name: Trigger Multisig Ops Sync
 
 on:

--- a/.github/workflows/trigger_multisig_ops_sync.yaml
+++ b/.github/workflows/trigger_multisig_ops_sync.yaml
@@ -1,0 +1,60 @@
+name: Trigger Multisig Ops Sync
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  trigger_sync:
+    # Only run if PR was merged and title contains "Biweekly Fee Report"
+    if: |
+      github.event.pull_request.merged == true && 
+      contains(github.event.pull_request.title, 'Biweekly Fee Report')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract dates from PR title
+        id: extract-dates
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          echo "PR Title: $PR_TITLE"
+          
+          if [[ "$PR_TITLE" =~ ending[[:space:]]+([0-9]{4}-[0-9]{2}-[0-9]{2}) ]]; then
+            END_DATE="${BASH_REMATCH[1]}"
+            echo "end-date=$END_DATE" >> $GITHUB_OUTPUT
+            
+            # Calculate start date (14 days before end date)
+            START_DATE=$(date -d "$END_DATE - 14 days" +%Y-%m-%d 2>/dev/null || date -j -v-14d -f "%Y-%m-%d" "$END_DATE" +%Y-%m-%d)
+            echo "start-date=$START_DATE" >> $GITHUB_OUTPUT
+            
+            echo "Extracted dates: $START_DATE to $END_DATE"
+          else
+            echo "Could not extract date from PR title"
+            exit 1
+          fi
+
+      - name: Trigger multisig-ops workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.MULTISIG_OPS_PAT }}
+          repository: BalancerMaxis/multisig-ops
+          event-type: fee_report_merged
+          client-payload: |
+            {
+              "start_date": "${{ steps.extract-dates.outputs.start-date }}", 
+              "end_date": "${{ steps.extract-dates.outputs.end-date }}", 
+              "pr_number": "${{ github.event.pull_request.number }}",
+              "pr_title": "${{ github.event.pull_request.title }}"
+            }
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ Fee distribution files synced to multisig-ops\n\nDates: ${{ steps.extract-dates.outputs.start-date }} to ${{ steps.extract-dates.outputs.end-date }}'
+            })


### PR DESCRIPTION
current flow:
1. fee report PR is merged and triggers `trigger_multisig_ops_sync.yaml`
2. `trigger_multisig_ops_sync.yaml` sends repository_dispatch to multisig-ops which triggers `sync_fee_distribution_artifacts.yaml` (exists in multisig-ops)
3. `sync_fee_distribution_artifacts.yaml` runs  `fetch_fee_artifacts.py`
4. `fetch_fee_artifacts.py` fetches payload/artifact files from the merged fee run and PRs it in multisig-ops

contains a new `MULTISIG_OPS_PAT` secret in order to communicate with msig ops repo
