### PR TITLE
fix branch name in trigger_multisig_ops_sync.yaml

### DIFF
--- a/.github/workflows/trigger_multisig_ops_sync.yaml
+++ b/.github/workflows/trigger_multisig_ops_sync.yaml
@@ -7,7 +7,7 @@ name: Trigger Multisig Ops Sync
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches: [biweekly-runs]
 
 jobs:
   trigger_sync:


### PR DESCRIPTION
updates to trigger action when a fee run PR is merged into `biweekly-runs`, not `main`