### PR TITLE
fix: revert aura vebal share calc

### DIFF
--- a/fee_allocator/accounting/chains.py
+++ b/fee_allocator/accounting/chains.py
@@ -83,7 +83,6 @@ class CorePoolRunConfig:
         self.cache_dir.mkdir(exist_ok=True)
 
         self._chains: Union[dict[str, CorePoolChain], None] = None
-        self.aura_vebal_share: Union[Decimal, None] = None
         self.protocol_version = protocol_version
 
 
@@ -116,15 +115,6 @@ class CorePoolRunConfig:
                 _chains[chain_name] = chain
 
         self._chains = _chains
-
-    def set_aura_vebal_share(self):
-        if not self.mainnet:
-            raise ValueError(
-                "mainnet must be initialized to calculate aura vebal share"
-            )
-        self.aura_vebal_share = self.mainnet.subgraph.calculate_aura_vebal_share(
-            self.mainnet.web3, self.mainnet.block_range[1]
-        )
 
     def set_initial_pool_allocation(self) -> None:
         """

--- a/fee_allocator/accounting/models.py
+++ b/fee_allocator/accounting/models.py
@@ -15,7 +15,7 @@ class PoolOverride(BaseModel):
 
 
 class GlobalFeeConfig(BaseModel):
-    min_aura_incentive: int = 0
+    min_total_bribe_threshold: int = 0
 
     vebal_share_pct: Decimal
     dao_share_pct: Decimal
@@ -27,8 +27,8 @@ class GlobalFeeConfig(BaseModel):
     beets_share_pct: Decimal
 
     @model_validator(mode="after")
-    def set_dynamic_min_aura_incentive(self):
-        self.min_aura_incentive = StakeDAO().calculate_dynamic_min_incentive()
+    def set_dynamic_min_total_bribe_threshold(self):
+        self.min_total_bribe_threshold = StakeDAO().calculate_dynamic_min_incentive()
         return self
 
 

--- a/fee_allocator/fee_allocator.py
+++ b/fee_allocator/fee_allocator.py
@@ -70,7 +70,6 @@ class FeeAllocator:
         Non-core pools: 82.5% veBAL, 17.5% DAO
         """
         self.run_config.set_core_pool_chains_data()
-        self.run_config.set_aura_vebal_share()
         self.run_config.set_initial_pool_allocation()
         if redistribute:
             self.redistribute_fees()
@@ -80,13 +79,11 @@ class FeeAllocator:
         Redistributes fees among pools based on minimum incentive amounts.
 
         Pools with total incentives below the minimum threshold get their incentives
-        redistributed to eligible pools above the threshold. The threshold is scaled
-        by Aura's veBAL share to ensure the effective Aura incentive meets the minimum.
+        redistributed to eligible pools above the threshold.
+
         """
-        min_aura = Decimal(self.run_config.fee_config.min_aura_incentive)
-        aura_share = self.run_config.aura_vebal_share
-        min_amount = min_aura / aura_share
-        logger.info(f"Redistribution threshold: ${min_amount:.0f} (${min_aura:.0f} min Aura / {aura_share:.2%} veBAL share)")
+        min_amount = self.run_config.fee_config.min_aura_incentive
+        logger.info(f"Redistribution threshold: ${min_amount}")
 
         for chain in self.run_config.all_chains:
             pools_to_redistribute = [p for p in chain.core_pools if p.total_to_incentives_usd < min_amount]
@@ -517,9 +514,7 @@ class FeeAllocator:
             "createdAt": int(datetime.datetime.now().timestamp()),
             "periodStart": self.date_range[0],
             "periodEnd": self.date_range[1],
-            "minAuraIncentive": self.run_config.fee_config.min_aura_incentive,
-            "auraVebalShare": float(round(self.run_config.aura_vebal_share, 4)),
-            "bribeThreshold": int(self.run_config.fee_config.min_aura_incentive / self.run_config.aura_vebal_share)
+            "bribeThreshold": self.run_config.fee_config.min_aura_incentive
         }
 
         recon_file = Path(PROJECT_ROOT) / "fee_allocator/summaries" / f"{self.run_config.protocol_version}_recon.json"

--- a/fee_allocator/fee_allocator.py
+++ b/fee_allocator/fee_allocator.py
@@ -82,7 +82,7 @@ class FeeAllocator:
         redistributed to eligible pools above the threshold.
 
         """
-        min_amount = self.run_config.fee_config.min_aura_incentive
+        min_amount = self.run_config.fee_config.min_total_bribe_threshold
         logger.info(f"Redistribution threshold: ${min_amount}")
 
         for chain in self.run_config.all_chains:
@@ -514,7 +514,7 @@ class FeeAllocator:
             "createdAt": int(datetime.datetime.now().timestamp()),
             "periodStart": self.date_range[0],
             "periodEnd": self.date_range[1],
-            "bribeThreshold": self.run_config.fee_config.min_aura_incentive
+            "bribeThreshold": self.run_config.fee_config.min_total_bribe_threshold
         }
 
         recon_file = Path(PROJECT_ROOT) / "fee_allocator/summaries" / f"{self.run_config.protocol_version}_recon.json"


### PR DESCRIPTION
aura is already accounted for, see https://github.com/BalancerMaxis/bal_tools/blob/fa36f362a900d48c768b6a1c07beba5e99ff6a20/bal_tools/ecosystem.py#L235-L248

variable name is confusing so that is being refactored here